### PR TITLE
Move browserify to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "babelify": "^7.3.0",
+    "browserify": "^13.0.1",
     "cpx": "^1.5.0",
     "cross-env": "^1.0.8",
     "eslint": "^3.4.0",
@@ -42,7 +43,6 @@
     "tape-run": "^3.0.0"
   },
   "dependencies": {
-    "browserify": "^13.0.1",
     "custom-event-polyfill": "^0.3.0"
   },
   "author": {


### PR DESCRIPTION
When requiring `custom-select` in a new app, I found that yarn installed a 129 packages. 128 of those came in via the browserify dependency.

I guess browserify is used to build the files in the build folder, but I think that is done in a context where dev dependencies are installed.

When looking inside `custom-select`, I see a `build` folder inside with some files that are usable with other AMD compatible loaders. We happen to be using a different one, so for us the package is usable without browserify.

Would be awesome if the depenency tree was a bit leaner.

If I'm wrong / missing something, do let me know.