### PR TITLE
Do not crash when removing the last item

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -264,7 +264,10 @@ function builder(el, builderParams) {
   }
 
   function changeEvent() {
-    setSelectedElement(select.options[select.selectedIndex].customSelectCstOption);
+    var index = select.selectedIndex,
+      element = index === -1 ? undefined : select.options[index].customSelectCstOption;
+
+    setSelectedElement(element);
   }
 
   // When the option is outside the visible part of the opened panel, updates the scrollTop position

--- a/src/test/index.js
+++ b/src/test/index.js
@@ -8,5 +8,6 @@ import './set-get-value';
 import './append';
 import './insert-before';
 import './remove';
+import './remove-last';
 import './empty';
 import './destroy';

--- a/src/test/remove-last.js
+++ b/src/test/remove-last.js
@@ -1,0 +1,59 @@
+import test from 'tape';
+import customSelect from './../';
+
+let actual;
+let expected;
+
+document.body.innerHTML = '';
+const select = document.createElement('select');
+select.innerHTML = `
+  <option value="mercedes">Mercedes</option>
+`;
+document.body.appendChild(select);
+const customselect = customSelect('select')[0];
+
+test('Remove last option', assert => {
+    var target = select.children[0]; // Mercedes option
+
+    const removed = customselect.remove(target);
+
+    assert.test('... and the returned option is the same', q => {
+        actual = removed;
+        expected = target;
+        q.deepEqual(actual, expected,
+            'the two elements should be the same');
+        q.end();
+    });
+
+    assert.test('... and the option is not in the select anymore', q => {
+        actual = Array.prototype.indexOf.call(select.options, removed);
+        expected = -1;
+        q.deepEqual(actual, expected,
+            'should be -1');
+        q.end();
+    });
+
+    assert.test('... and the custom option is not in the panel anymore', q => {
+        actual = customselect.panel.querySelectorAll(`[data-value="${removed.getAttribute('value')}"]`);
+        expected = 0;
+        q.deepEqual(actual.length, expected,
+            'should be 0');
+        q.end();
+    });
+
+    assert.test('... and the custom options are one less', q => {
+        actual = customselect.panel.getElementsByClassName(customselect.pluginOptions.optionClass);
+        expected = 0;
+        q.deepEqual(actual.length, expected,
+            'should be 0');
+        q.end();
+    });
+
+    assert.test('... and the value is that of the first option', q => {
+        actual = customselect.panel.getElementsByClassName(customselect.pluginOptions.optionClass);
+        expected = '';
+        q.equal(customselect.value, expected,
+            'should be ""');
+        q.end();
+    });
+});


### PR DESCRIPTION
Removing the last item of a pulldown currently crashes with this error
```
TypeError: Cannot read property 'customSelectCstOption' of undefined
```
Possible workaround would be to use the `empty()` method, but it doesn't feel right when you're only removing one item.