### PR TITLE
Use array prototype over array creation

### DIFF
--- a/src/test/empty.js
+++ b/src/test/empty.js
@@ -20,7 +20,7 @@ const customselect = customSelect('select')[0];
 let removed;
 
 test('Empty select (remove any option)', assert => {
-  const expectedRemoved = [].slice.call(customselect.select.children);
+  const expectedRemoved = Array.prototype.slice.call(customselect.select.children);
   removed = customselect.empty();
 
   assert.test('... and the returned all select child', q => {

--- a/src/test/remove.js
+++ b/src/test/remove.js
@@ -35,7 +35,7 @@ test('Remove an option', assert => {
   });
 
   assert.test('... and the option is not in the select anymore', q => {
-    actual = [].indexOf.call(select.options, removed);
+    actual = Array.prototype.indexOf.call(select.options, removed);
     expected = -1;
     q.deepEqual(actual, expected,
       'should be -1');
@@ -81,7 +81,7 @@ test('Remove an option group', assert => {
   });
 
   assert.test('... and the option group is not in the select anymore', q => {
-    actual = [].indexOf.call(select.getElementsByTagName('optgroup'),
+    actual = Array.prototype.indexOf.call(select.getElementsByTagName('optgroup'),
       removedGroup.customSelectOriginalOptgroup);
     expected = -1;
     q.deepEqual(actual, expected,
@@ -90,7 +90,7 @@ test('Remove an option group', assert => {
   });
 
   assert.test('... and the custom option group is not in the panel anymore', q => {
-    actual = [].indexOf.call(select.getElementsByTagName(customselect.pluginOptions.optgroupClass),
+    actual = Array.prototype.indexOf.call(select.getElementsByTagName(customselect.pluginOptions.optgroupClass),
       removedGroup.customSelectOriginalOptgroup);
     expected = -1;
     q.deepEqual(actual, expected,


### PR DESCRIPTION
Noticed that there was a usage of `[].slice.call`, which is identical to `Array.prototype.slice.call` except the latter one doesn't create a new array.

Also see: https://stackoverflow.com/a/7057017/2450427

Basically: both work great, but for me it feels useless to create the empty array.