### PR TITLE
Fix optgroup cleanup in destroy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -477,7 +477,7 @@ function builder(el, builderParams) {
     }
     const optGroup = select.getElementsByTagName('optgroup');
     for (let i = 0, l = optGroup.length; i < l; i++) {
-      delete optGroup.customSelectCstOptgroup;
+      delete optGroup[i].customSelectCstOptgroup;
     }
 
     removeEvents();

--- a/src/test/destroy.js
+++ b/src/test/destroy.js
@@ -30,4 +30,13 @@ test('Destroy the custom select', assert => {
       'should return true');
     q.end();
   });
+
+  assert.test('... and optgroup references are removed', q => {
+    const optgroups = select.querySelectorAll('optgroup');
+    for (let i = 0; i < optgroups.length; i++) {
+      q.equal(typeof optgroups[i].customSelectCstOptgroup, 'undefined',
+        'should remove reference to custom optgroup');
+    }
+    q.end();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `destroy` removes custom optgroup references
- add regression test verifying optgroup references cleaned up

## Testing
- `npm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6894b940ef54832d922e6fbe7b8bdefc